### PR TITLE
fix: establisment/write fails when non-ascii characters in company name

### DIFF
--- a/src/PrhApi/Repositories/CompanyEstablishmentS3Repository.cs
+++ b/src/PrhApi/Repositories/CompanyEstablishmentS3Repository.cs
@@ -54,7 +54,6 @@ public class CompanyEstablishmentS3Repository : ICompanyEstablishmentRepository
             ContentType = "application/json",
             ContentBody = JsonSerializer.Serialize(details)
         };
-        //request.Metadata.Add("company-name", details.CompanyDetails.Name);
 
         try
         {

--- a/src/PrhApi/Repositories/CompanyEstablishmentS3Repository.cs
+++ b/src/PrhApi/Repositories/CompanyEstablishmentS3Repository.cs
@@ -54,7 +54,7 @@ public class CompanyEstablishmentS3Repository : ICompanyEstablishmentRepository
             ContentType = "application/json",
             ContentBody = JsonSerializer.Serialize(details)
         };
-        request.Metadata.Add("company-name", details.CompanyDetails.Name);
+        //request.Metadata.Add("company-name", details.CompanyDetails.Name);
 
         try
         {
@@ -89,7 +89,7 @@ public class CompanyEstablishmentS3Repository : ICompanyEstablishmentRepository
         {
             var company = await LoadWithObjectKey(key);
             if (company is null) continue;
-            
+
             companies.Add(new UserCompany
             {
                 NationalIdentifier = S3ObjectKey.GetBusinessIdFromS3ObjectKey(key),


### PR DESCRIPTION
fix: omit the company-name s3-bucket metadata key saving as it's not used but breaks the upload when there's non-ascii words in the company name